### PR TITLE
Improve parser error handling

### DIFF
--- a/src/cmd/repo.rs
+++ b/src/cmd/repo.rs
@@ -62,7 +62,7 @@ fn add(path: PathBuf) -> Result<()> {
             Err(err) => {
                 if err
                     .to_string()
-                    .contains("UNIQUE constraint failed: repo.path")
+                    .contains("UNIQUE constraint failed: context_repo.context, context_repo.repo")
                 {
                     Err(Error::RepoExists(repo.clone()).into())
                 } else {

--- a/src/db.rs
+++ b/src/db.rs
@@ -234,7 +234,8 @@ pub mod repo {
         let encoded = serde_json::to_string(repo)?;
         let path = repo.path_as_string();
 
-        let mut stmt = conn.prepare("INSERT INTO repo (path, json) VALUES (:path, :json)")?;
+        let mut stmt =
+            conn.prepare("INSERT OR IGNORE INTO repo (path, json) VALUES (:path, :json)")?;
         stmt.execute_named(&[(":path", &path), (":json", &encoded)])
             .map_err(|e| Error::Query(e).into())
             .map(|_| ())

--- a/src/db.rs
+++ b/src/db.rs
@@ -9,7 +9,7 @@ use {
 enum Error {
     #[error("Cannot read database path")]
     DbPath,
-    #[error("Error while querying database: {0}")]
+    #[error("Querying database: {0}")]
     Query(#[from] sql::Error),
     #[error("Context {0} does not exists")]
     NonexistentContext(String),

--- a/src/pandoc.rs
+++ b/src/pandoc.rs
@@ -43,12 +43,7 @@ fn pandoc_from_bytes(b: &[u8]) -> Result<Pandoc> {
         [] => Err(Error::PandocData("no data received from pandoc".into()).into()),
         _ => serde_json::from_str(String::from_utf8_lossy(b).as_ref())
             .map_err(|e: serde_json::Error| -> Error { Error::Serialization(e) })
-            .with_context(|| {
-                format!(
-                    "deserializing pandoc JSON output: {}",
-                    String::from_utf8_lossy(b)
-                )
-            }),
+            .context("deserializing pandoc JSON output"),
     }
 }
 


### PR DESCRIPTION
Closes #65 by providing an error that lets us clearly identify the
source of the problem (on the basis of an overhaul of the error handling
in this part of the code).